### PR TITLE
Add standard extensions for race and ethnicity.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: node_js
 node_js:
-  - "4.1"
+  - "6.1"
 services:
   - mongodb
 script: mocha

--- a/lib/core.js
+++ b/lib/core.js
@@ -15,7 +15,9 @@ let core = {
                    "http://hl7.org/fhir/sid/icd-9": "ICD-9-CM",
                    "http://hl7.org/fhir/sid/icd-10": "ICD-10-PCS",
                    "http://www.fda.gov/Drugs/InformationOnDrugs": "NDC",
-                   "http://www2a.cdc.gov/vaccines/iis/iisstandards/vaccines.asp?rpt=cvx": "CVX"};
+                   "http://www2a.cdc.gov/vaccines/iis/iisstandards/vaccines.asp?rpt=cvx": "CVX",
+                   "http://hl7.org/fhir/v3/Race": "CDC Race",
+                   "http://hl7.org/fhir/v3/Ethnicity": "CDC Ethnicity"};
       this.csn = csMap[codeSystemName];
     }
 

--- a/lib/patient.js
+++ b/lib/patient.js
@@ -96,16 +96,30 @@ class Patient {
     return this.fhirModel.deceasedBoolean;
   }
 
-  // Stub for now. Not a core part of FHIR
-  // It is included in DAF Profile of Patient
-  race() {
+  getExtension(url) {
+    this.populate();
+    let list = this.fhirModel.extension;
+    if (list != null) {
+      for(var i = 0; i < list.length; i++) {
+        let ext = list[i];
+        if (ext.url == url) {
+          return core.firstCode(ext.valueCodeableConcept);
+        }
+      }
+    }
     return null;
   }
 
-  // Stub for now. Not a core part of FHIR
+  // Not a core part of FHIR
+  // It is included in DAF Profile of Patient
+  race() {
+    return this.getExtension("http://hl7.org/fhir/StructureDefinition/us-core-race");
+  }
+
+  // Not a core part of FHIR
   // It is included in DAF Profile of Patient
   ethnicity() {
-    return null;
+    return this.getExtension("http://hl7.org/fhir/StructureDefinition/us-core-ethnicity");
   }
 
   languages() {

--- a/lib/patient.js
+++ b/lib/patient.js
@@ -103,7 +103,7 @@ class Patient {
       for(var i = 0; i < list.length; i++) {
         let ext = list[i];
         if (ext.url == url) {
-          return core.firstCode(ext.valueCodeableConcept);
+          return core.firstCodedValue(ext.valueCodeableConcept);
         }
       }
     }

--- a/test/fixtures/patient.json
+++ b/test/fixtures/patient.json
@@ -26,5 +26,33 @@
             "state" : "AR",
             "postalCode" : "0938848"
         }
+    ],
+    "extension": [
+      {
+        "url": "http://hl7.org/fhir/StructureDefinition/us-core-race",
+        "valueCodeableConcept": {
+          "coding": [
+            {
+              "system": "http://hl7.org/fhir/v3/Race",
+              "code": "2115-4",
+              "display": "Polish"
+            }
+          ],
+          "text": "race"
+        }
+      },
+      {
+        "url": "http://hl7.org/fhir/StructureDefinition/us-core-ethnicity",
+        "valueCodeableConcept": {
+          "coding": [
+            {
+              "system": "http://hl7.org/fhir/v3/Ethnicity",
+              "code": "2186-5",
+              "display": "Nonhispanic"
+            }
+          ],
+          "text": "ethnicity"
+        }
+      }
     ]
 }

--- a/test/patient-test.js
+++ b/test/patient-test.js
@@ -213,7 +213,9 @@ describe('Patient', () => {
   it('has a race', (done) => {
     new Fiber(() => {
       let patient = new fhir.Patient(database, patientId);
-      assert.equal('2115-4', patient.race());
+      let race = patient.race();
+      assert.equal('2115-4', race.code());
+      assert.equal('CDC Race', race.codeSystemName());
       done();
     }).run();
   });
@@ -221,7 +223,9 @@ describe('Patient', () => {
   it('has an ethnicity', (done) => {
     new Fiber(() => {
       let patient = new fhir.Patient(database, patientId);
-      assert.equal('2186-5', patient.ethnicity());
+      let ethnicity = patient.ethnicity();
+      assert.equal('2186-5', ethnicity.code());
+      assert.equal('CDC Ethnicity', ethnicity.codeSystemName());
       done();
     }).run();
   });

--- a/test/patient-test.js
+++ b/test/patient-test.js
@@ -210,6 +210,22 @@ describe('Patient', () => {
     }).run();
   });
 
+  it('has a race', (done) => {
+    new Fiber(() => {
+      let patient = new fhir.Patient(database, patientId);
+      assert.equal('2115-4', patient.race());
+      done();
+    }).run();
+  });
+
+  it('has an ethnicity', (done) => {
+    new Fiber(() => {
+      let patient = new fhir.Patient(database, patientId);
+      assert.equal('2186-5', patient.ethnicity());
+      done();
+    }).run();
+  });
+
   after(() => {
     database.collection("patients").drop();
     database.collection("encounters").drop();


### PR DESCRIPTION
The `race` and `ethnicity` methods return the coded value as a string. Not sure if this is the expected behavior, or if it should be a `CodedValue` or `CodedEntry`.
